### PR TITLE
VT-5648 Open Cart: Not All Products are Receiving Quantity Updates (issue for different versions)

### DIFF
--- a/src/OpenCartAccess/Models/Product/OpenCartProduct.cs
+++ b/src/OpenCartAccess/Models/Product/OpenCartProduct.cs
@@ -13,5 +13,41 @@ namespace OpenCartAccess.Models.Product
 
 		[ DataMember( Name = "quantity" ) ]
 		public int Quantity { get; set; }
+
+		#region Equality members
+		public bool Equals( OpenCartProduct other )
+		{
+			if( ReferenceEquals( null, other ) )
+				return false;
+			if( ReferenceEquals( this, other ) )
+				return true;
+			return this.Id.Equals( other.Id ) &&
+			       this.Sku.Equals( other.Sku ) &&
+			       this.Quantity.Equals( other.Quantity );
+		}
+
+		public override bool Equals( object obj )
+		{
+			if( ReferenceEquals( null, obj ) )
+				return false;
+			if( ReferenceEquals( this, obj ) )
+				return true;
+			if( obj.GetType() != this.GetType() )
+				return false;
+			return this.Equals( ( OpenCartProduct )obj );
+		}
+
+		public override int GetHashCode()
+		{
+			unchecked
+			{
+				var result = this.Id.GetHashCode();
+				result = ( result * 397 ) ^ this.Sku.GetHashCode();
+				result = ( result * 397 ) ^ this.Quantity.GetHashCode();
+
+				return result;
+			}
+		}
+		#endregion
 	}
 }


### PR DESCRIPTION
Issue: looks like we have three version of OpenCart. On the same API they returns different behavior and response.

1. Accounts like https://valvestore.forfansbyfans.com. They don't work with paging and return all products always. This is reason of this issue.
2. Accounts like https://synthcube.com. They work with paging and without paging.
3. Accounts like https://prestacart.courtneyscandles.com. They work only with paging. This is source of issue in ticket VT-5621.

What did I do here?

I added condition for searching unique items. I.e for accounts of type #1 we will receive all products in first request and will receive them again on second request. After that - we will break loop. I know that it isn't super idea, but I wasn't able to search any differences between responses for these accounts. These response doesn't have any version and etc.